### PR TITLE
Updates Travis CI info to reflect master build link/status

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 
 Angular module for the popular Packery library.
 
-![Travis CI](https://api.travis-ci.org/SunGard-Labs/angular-packery.png)
+[![Travis CI](https://api.travis-ci.org/SunGard-Labs/angular-packery.svg?branch=master)](http://travis-ci.org/SunGard-Labs/angular-packery)
 
 
 #### Requirements ####


### PR DESCRIPTION
This will properly reflect the master branch's build status and link to the Travis CI page correctly.