### PR TITLE
Including AngularJs and Packery as dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,10 @@
     "url": "http://github.com/sungard-labs/angular-packery.git"
   },
   "main": "dist/packery.js",
+  "dependencies": {
+-    "angular": ">=1.2.26 <1.4",
+-    "packery": ">=1.2.0 <1.3"
+-  },
   "keywords": [
     "packery",
     "angular",


### PR DESCRIPTION
If not including dependencies in bower.json, gulp-angular-filesort will fail...
